### PR TITLE
Fix failing test in memory.spec.js

### DIFF
--- a/tests/memory.spec.js
+++ b/tests/memory.spec.js
@@ -60,7 +60,7 @@ describe('MemoryGame', () => {
     });
 
     it('should return undefined if argument (cards array) is not passed', () => {
-      expect(typeof memoryGame.shuffleCards()).toBe('undefined');
+      expect(typeof new MemoryGame().shuffleCards()).toBe('undefined');
     });
 
     it('should return the shuffled (mixed) array of cards', () => {


### PR DESCRIPTION
```
   it('should return undefined if argument (cards array) is not passed', () => {
      expect(typeof memoryGame.shuffleCards()).toBe('undefined');
    });

```
Never passes because for each test an instancewith an array of cards is always defined

```
beforeEach(() => {
      memoryGame = new MemoryGame(cardsArray);
    });

```
