### PR TITLE
corrections on Jasmine tests

### DIFF
--- a/tests/memory.spec.js
+++ b/tests/memory.spec.js
@@ -63,10 +63,21 @@ describe('MemoryGame', () => {
     });
 
     it('should return the shuffled (mixed) array of cards', () => {
-      const formerCards = memoryGame.cards.map((card) => card.name).toString();
-      memoryGame.shuffleCards();
-      const newCards = memoryGame.cards.map((card) => card.name).toString();
-      expect(formerCards === newCards).toBe(false);
+      const iterations = 100;
+      let isShuffled = false;
+
+      for (let i = 0; i < iterations; i++) {
+        const formerCards = [...memoryGame.cards];
+        memoryGame.shuffleCards();
+        const newCards = memoryGame.cards;
+
+        if (formerCards.some((card, index) => card.name !== newCards[index].name)) {
+          isShuffled = true;
+          break;
+        }
+      }
+
+      expect(isShuffled).toBe(true);
     });
   });
 
@@ -112,11 +123,14 @@ describe('MemoryGame', () => {
 
     it("should return false if there's still some pairs to be guessed", () => {
       memoryGame.pairsGuessed = 4;
+      memoryGame.cards = new Array(16)
       expect(memoryGame.checkIfFinished()).toBe(false);
     });
 
     it('should return true if all pairs are guessed', () => {
-      memoryGame.pairsGuessed = 8;
+      memoryGame.pairsGuessed = 8
+      memoryGame.pairsClicked = 1;
+      memoryGame.cards = new Array(16)
       expect(memoryGame.checkIfFinished()).toBe(true);
     });
   });


### PR DESCRIPTION
### 1) Correction on last test (`'should return true if all pairs are guessed'`) so the correct implentation passes.

The original test was failing even with a correct implementation of the `checkIfFinished `method. This was due to two issues:

**1.1. Issue with `pairsGuessed `and `cards.length`**: The test was setting `memoryGame.pairsGuessed = 8`, but it wasn't setting `memoryGame.cards.length`. As a result, the condition `this.pairsGuessed === this.cards.length / 2` in the `checkIfFinished` method was returning false, causing the test to fail even if the function is correctly implemented. This has been fixed by setting `memoryGame.cards = new Array(16)` in this spec of the test.

**1.2. Issue with `pairsClicked`**: The `checkIfFinished` method returns false if `pairsClicked `is 0. However, the test wasn't setting `pairsClicked` to a non-zero value (which will be the case when `pairsGuessed` are larger than 1) in the `'should return true if all pairs are guessed'` spec, also causing the test to fail even if the function is correctly implemented.
This has been fixed by setting `memoryGame.pairsClicked = 1` in that spec.

### 2) Correction of  `'should return the shuffled (mixed) array of cards'`

The test is not correctly implemented. It was simply checking if the returned array is different from the passed array, which could lead to false positives

The new test simulates a more realistic scenario by running the shuffle operation multiple times, and then checking if at least one card has changed its position in the array after the shuffle. This approach is more reliable and increases the likelihood of catching a faulty shuffle operation, as it's statistically improbable for a correctly implemented shuffle to maintain the original order of cards across multiple iterations.